### PR TITLE
fix: always update project config in store to propagate changes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(find /home/rvg/src/a/rvangemmeren_aedifion/gitlab-ci-pipelines-exporter -maxdepth 2 -type f \\\\\\(-name .gitlab-ci.yml -o -name .github -o -name Dockerfile* -o -name README.md -o -name CLAUDE.md -o -name .cursorrules -o -name *.md \\\\\\))",
+      "Bash(npx markdownlint-cli2:*)",
+      "mcp__context7__resolve-library-id",
+      "mcp__context7__query-docs",
+      "Bash(go test:*)",
+      "Bash(go tool:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
+    ]
+  }
+}

--- a/.goreleaser.pre.yml
+++ b/.goreleaser.pre.yml
@@ -12,11 +12,7 @@ builds:
       - linux
       - windows
     goarch:
-      - 386
       - amd64
-      - arm
-      - arm64
-    goarm: [6, 7]
     flags:
       - -trimpath
     ignore:
@@ -28,10 +24,10 @@ universal_binaries:
   - {}
 
 archives:
-  - name_template: '{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  - name_template: "{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     format_overrides:
       - goos: windows
-        formats: [ 'zip' ]
+        formats: ["zip"]
     files:
       - README.md
       - LICENSE
@@ -43,7 +39,7 @@ nfpms:
     license: &license Apache-2.0
     homepage: https://github.com/mvisonneau/gitlab-ci-pipelines-exporter
     vendor: *author
-    file_name_template: '{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    file_name_template: "{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     bindir: /usr/local/bin
     formats:
       - apk
@@ -102,16 +98,16 @@ signs:
   - artifacts: checksum
     args:
       [
-        '-u',
-        'C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE',
-        '--output',
-        '${signature}',
-        '--detach-sign',
-        '${artifact}',
+        "-u",
+        "C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE",
+        "--output",
+        "${signature}",
+        "--detach-sign",
+        "${artifact}",
       ]
 
 checksum:
-  name_template: '{{ .ProjectName }}_edge_sha512sums.txt'
+  name_template: "{{ .ProjectName }}_edge_sha512sums.txt"
   algorithm: sha512
 
 changelog:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code)
+when working with code in this repository.
+
+## Project Overview
+
+A Prometheus/OpenMetrics exporter that monitors GitLab CI
+pipelines, jobs, and environments.
+Module: `github.com/mvisonneau/gitlab-ci-pipelines-exporter`.
+Go 1.25.5.
+
+## Commands
+
+```bash
+make fmt       # Format code (golangci-lint fmt)
+make lint      # Run linters (golangci-lint run)
+make test      # Run tests with race detector + coverage
+make install   # Build and install binary locally
+make build     # Build binaries via goreleaser snapshot
+make all       # lint + test + build + coverage
+make protoc    # Regenerate protobuf
+make dev-env   # Docker-based dev env on port 8080
+```
+
+Run a single test:
+
+```bash
+go test -v -run TestFunctionName ./pkg/controller/
+```
+
+## Architecture
+
+### Data Flow (cascading task-based collection)
+
+```text
+Wildcards → Projects → Refs (branches/tags/MRs)
+                       → Pipelines → Jobs
+                     → Environments → Deployments
+```
+
+The **Controller** (`pkg/controller/`) is the central
+orchestrator. It owns config, GitLab client, store, task
+queue, and rate limiter. All collection is async via `taskq`
+— either Redis-backed (`redisq`) for clustering or in-memory
+(`memqueue`) for single-instance.
+
+### Key Packages
+
+- `cmd/gitlab-ci-pipelines-exporter` — Entry point,
+  delegates to `internal/cli`
+- `internal/cli` — CLI framework and command definitions
+- `internal/cmd` — `Run()` startup: config load →
+  controller init → HTTP server → scheduler
+- `pkg/controller` — Core orchestrator: scheduling,
+  pulling, garbage collection, metrics handler
+- `pkg/config` — YAML config parsing with hierarchical
+  defaults (global → project)
+- `pkg/schemas` — Data models: Project, Ref, Environment,
+  Pipeline, Job, Metric. Entities use CRC32 hash keys
+- `pkg/store` — Dual-backend store interface: Redis
+  (`redis.go`) or local in-memory (`local.go`)
+- `pkg/gitlab` — GitLab API wrapper with rate limiting,
+  health checks, OpenTelemetry tracing
+- `pkg/ratelimit` — Rate limiting: Redis-distributed or
+  local token bucket
+- `pkg/monitor` — gRPC monitoring server for task health
+
+### HTTP Endpoints (`internal/cmd/run.go`)
+
+- `/metrics` — Prometheus metrics
+- `/health/live`, `/health/ready` — health probes
+  (readiness checks GitLab reachability)
+- `/webhook` — GitLab webhook ingestion
+- `/debug/pprof/*` — profiling
+
+### Task Types (`pkg/schemas/tasks.go`)
+
+14 task types covering: pull wildcards/projects, pull
+refs/environments from projects, pull ref/environment
+metrics, and garbage collection for each entity type. Tasks
+are scheduled periodically and cascade — top-level tasks
+spawn sub-tasks for discovered entities.
+
+## Testing Conventions
+
+- **Framework**: `github.com/stretchr/testify/assert`
+- **Mocking**: Manual HTTP mocking via `net/http/httptest`
+  — no external mock frameworks
+- **Pattern**: Table-driven tests with `t.Run()` subtests
+- **Redis tests**: `github.com/alicebob/miniredis/v2`
+  for in-memory Redis
+- **Test helpers**: `newMockedGitlabAPIServer()`,
+  `newTestController()` in controller test files
+
+## Linting (`.golangci.yml`)
+
+Enabled linters: errcheck, gosec, govet, ineffassign,
+staticcheck, unused. Line length limit: 140. Import
+grouping: stdlib, third-party, then
+`github.com/mvisonneau` prefix (enforced by gci formatter).

--- a/pkg/controller/projects.go
+++ b/pkg/controller/projects.go
@@ -24,16 +24,16 @@ func (c *Controller) PullProject(ctx context.Context, name string, pull config.P
 		return err
 	}
 
+	if err := c.Store.SetProject(ctx, p); err != nil {
+		log.WithContext(ctx).
+			WithError(err).
+			Error()
+	}
+
 	if !projectExists {
 		log.WithFields(log.Fields{
 			"project-name": p.Name,
 		}).Info("discovered new project")
-
-		if err := c.Store.SetProject(ctx, p); err != nil {
-			log.WithContext(ctx).
-				WithError(err).
-				Error()
-		}
 
 		c.ScheduleTask(ctx, schemas.TaskTypePullRefsFromProject, string(p.Key()), p)
 		c.ScheduleTask(ctx, schemas.TaskTypePullEnvironmentsFromProject, string(p.Key()), p)
@@ -55,6 +55,12 @@ func (c *Controller) PullProjectsFromWildcard(ctx context.Context, w config.Wild
 			return err
 		}
 
+		if err := c.Store.SetProject(ctx, p); err != nil {
+			log.WithContext(ctx).
+				WithError(err).
+				Error()
+		}
+
 		if !projectExists {
 			log.WithFields(log.Fields{
 				"wildcard-search":                  w.Search,
@@ -64,12 +70,6 @@ func (c *Controller) PullProjectsFromWildcard(ctx context.Context, w config.Wild
 				"wildcard-archived":                w.Archived,
 				"project-name":                     p.Name,
 			}).Info("discovered new project")
-
-			if err := c.Store.SetProject(ctx, p); err != nil {
-				log.WithContext(ctx).
-					WithError(err).
-					Error()
-			}
 
 			c.ScheduleTask(ctx, schemas.TaskTypePullRefsFromProject, string(p.Key()), p)
 			c.ScheduleTask(ctx, schemas.TaskTypePullEnvironmentsFromProject, string(p.Key()), p)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -100,29 +100,18 @@ func New(
 		s = NewLocalStore()
 	}
 
-	// Load all the configured projects in the store
+	// Load all the configured projects in the store, always updating
+	// their configuration to ensure config changes are propagated
 	for _, p := range projects {
 		sp := schemas.Project{Project: p}
 
-		exists, err := s.ProjectExists(ctx, sp.Key())
-		if err != nil {
+		if err := s.SetProject(ctx, sp); err != nil {
 			log.WithContext(ctx).
 				WithFields(log.Fields{
 					"project-name": p.Name,
 				}).
 				WithError(err).
-				Error("reading project from the store")
-		}
-
-		if !exists {
-			if err = s.SetProject(ctx, sp); err != nil {
-				log.WithContext(ctx).
-					WithFields(log.Fields{
-						"project-name": p.Name,
-					}).
-					WithError(err).
-					Error("writing project in the store")
-			}
+				Error("writing project in the store")
 		}
 	}
 


### PR DESCRIPTION
## 💪 What

- Fixes project config not being updated in the store for already-discovered projects — `SetProject` is now called unconditionally in `PullProject`, `PullProjectsFromWildcard`, and store initialization
- Simplifies store init by removing check-then-write pattern in favor of always writing
- Trims pre-release goreleaser config to amd64-only and normalizes YAML quote style
- Adds Claude Code project configuration (`CLAUDE.md`)

## 🤔 Why

- When project configuration changed (e.g. enabling merge request pipeline tracking), the exporter never picked up those changes for projects already in the store — only newly discovered projects got the updated config
- The check-then-write pattern in store initialization had the same issue: config changes were silently ignored on restart if the project already existed in Redis/local store
- Pre-release builds don't need multi-arch — trimming speeds up edge builds

## 👩‍🔬 How to validate

1. Configure a project with `pull.pipeline.jobs.enabled: false`
2. Start the exporter, verify the project is discovered
3. Change config to `pull.pipeline.jobs.enabled: true` and restart
4. Verify the project now has jobs collection enabled (check metrics output)
5. Same flow works for wildcard-discovered projects